### PR TITLE
fix: update trigger terms to avoid conflicts with todu-workflow skills

### DIFF
--- a/skills/task-perform/SKILL.md
+++ b/skills/task-perform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-perform
-description: Start working on a task or habit and follow its instructions. Use when user says "get started on task #*", "work on task #*", "handle task #*", "do task #*", "work on habit #*", "handle habit #*", "do habit #*", or similar. (plugin:todu)
+description: Start working on a task or habit and follow its instructions. Use when user says "do task #*", "perform task #*", "execute task #*", "handle task #*", "work on task #*", "do habit #*", "handle habit #*", "work on habit #*", or similar. (plugin:todu)
 allowed-tools: todu, Bash, Read, Write, Edit, AskUserQuestion
 ---
 

--- a/skills/task-update/SKILL.md
+++ b/skills/task-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-update
-description: Update tasks/issues. Use when user says "update task #*", "mark task #* as *", "close task #*", "complete task #*", "set priority on #*", or similar. (plugin:todu)
+description: Update tasks/issues. Use when user says "update task #*", "mark task #* as *", "set priority on #*", "mark task done", "set task status to done", "quick close task", or similar. (plugin:todu)
 allowed-tools: todu
 ---
 


### PR DESCRIPTION
## Summary

Update trigger terms for `task-perform` and `task-update` to avoid conflicts with `task-start-preflight` and `task-close-preflight` from todu-workflow.

## Changes

### task-perform (#1336)

**Removed:**
- "get started on task"

**Added:**
- "perform task"
- "execute task"

**Kept:**
- "do task", "handle task", "work on task"
- All habit triggers unchanged

### task-update (#1338)

**Removed:**
- "close task"
- "complete task"

**Added:**
- "mark task done"
- "set task status to done"
- "quick close task"

**Kept:**
- "update task", "mark task as", "set priority on"

## Rationale

- "start/begin" = preflight/preparation (task-start-preflight)
- "do/perform/execute/work on" = follow instructions (task-perform)
- "close/complete/finish" = preflight verification (task-close-preflight)
- "mark done", "set status", "quick close" = direct action (task-update)

## Related

- Task #1336
- Task #1338
- todu-workflow PR #20 (task-start-preflight)
- todu-workflow PR #21 (task-close-preflight)